### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -3,7 +3,8 @@
 const path = require('path');
 const InertEntryPlugin = require('inert-entry-webpack-plugin');
 const loaderUtils = require('loader-utils');
-const { SingleEntryPlugin } = require('webpack');
+const isWebpack5 = require("webpack/package.json").version.startsWith("5.");
+const { [isWebpack5 ? "EntryPlugin" : "SingleEntryPlugin"]: EntryPlugin } = require('webpack');
 
 module.exports = function () {};
 
@@ -31,7 +32,7 @@ module.exports.pitch = function (request) {
     { filename: filename },
     plugins,
   );
-  new SingleEntryPlugin(this.context, '!!' + request, debugName).apply(
+  new EntryPlugin(this.context, '!!' + request, debugName).apply(
     compiler,
   );
 


### PR DESCRIPTION
Here is a fix to remove that deprecation warning.

```
(node:43263) [DEP_WEBPACK_SINGLE_ENTRY_PLUGIN] DeprecationWarning: SingleEntryPlugin was renamed to EntryPlugin
    at get SingleEntryPlugin (/Users/ollebroms/Documents/testing/node_modules/webpack/lib/index.js:271:4)
    at Function.SingleEntryPlugin (/Users/ollebroms/Documents/testing/node_modules/webpack/lib/util/memoize.js:22:13)
    at Object.<anonymous> (/Users/ollebroms/Documents/testing/node_modules/entry-chunk-loader/index.cjs:6:9)
    at Module._compile (/Users/ollebroms/Documents/testing/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (/Users/ollebroms/Documents/testing/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at loadLoader (/Users/ollebroms/Documents/testing/node_modules/loader-runner/lib/loadLoader.js:19:17)
```